### PR TITLE
fix: on sdk init, invoke method channel on main queue (#9)

### DIFF
--- a/ios/Classes/GleapSdkPlugin.m
+++ b/ios/Classes/GleapSdkPlugin.m
@@ -41,9 +41,9 @@
 }
 
 - (void)initialized {
-  if (self.methodChannel != nil) {
-    [self.methodChannel invokeMethod:@"initialized" arguments:@{}];
-  }
+  dispatch_async(dispatch_get_main_queue(), ^{
+      [self.methodChannel invokeMethod:@"initialized" arguments:@{}];
+  });
 }
 
 - (void)feedbackSendingFailed {


### PR DESCRIPTION
We've logged crashes in prod from Gleap's initialization callback. After the NSURLSession data task returns on a background queue, calling upon the Flutter method channel needs a hop to the main thread (which this PR does). See issue #9 as well.

It's likely other delegate callbacks that hit that channel need to hop to main as well, but I'll leave that scope to y'all. Thanks for supporting Flutter and all you do with Gleap.

<img width="1392" alt="Screenshot 2024-10-10 at 9 51 57 AM" src="https://github.com/user-attachments/assets/cb6cee32-a19e-40db-ab3e-bf53ef726296">
