### PR TITLE
fix: termination crash with detachFromEnginerForRegistrar

### DIFF
--- a/ios/Classes/GleapSdkPlugin.m
+++ b/ios/Classes/GleapSdkPlugin.m
@@ -21,6 +21,12 @@
   [Gleap setApplicationType:FLUTTER];
 }
 
+- (void)detachFromEngineForRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+  @synchronized(self) {
+    self.methodChannel = nil;
+  }
+}
+
 - (void)feedbackFlowStarted:(NSDictionary *)feedbackAction {
   if (self.methodChannel != nil) {
     [self.methodChannel invokeMethod:@"feedbackFlowStarted"


### PR DESCRIPTION
We see some rarer crashes logs when the system is terminating an iOS app and Gleap calls upon the Flutter engine, which has already spun down. (The error message is a bit of a misnomer, as the flutter engine may have been running, but now it is not.)

### References
https://api.flutter.dev/ios-embedder/protocol_flutter_plugin-p.html
https://github.com/flutter/flutter/issues/96901

### Sample traces
<img width="1236" alt="Screenshot 2024-10-15 at 5 29 09 PM" src="https://github.com/user-attachments/assets/90f39c8a-28f7-4b2a-bcff-2538d508d02c">
<img width="1224" alt="Screenshot 2024-10-15 at 5 29 21 PM" src="https://github.com/user-attachments/assets/47a18708-6b05-4d6a-9563-55268c4c65a9">
